### PR TITLE
Fix grid column count to respect double padding

### DIFF
--- a/Media Muncher/Constants.swift
+++ b/Media Muncher/Constants.swift
@@ -55,6 +55,7 @@ enum Constants {
     /// - Parameter width: Available width for the grid
     /// - Returns: Number of columns that fit with proper spacing
     static func gridColumnsCount(for width: CGFloat) -> Int {
-        return Int((width - gridPadding) / (gridColumnWidth + gridColumnSpacing))
+        let availableWidth = max(0, width - gridPadding * 2)
+        return Int(availableWidth / (gridColumnWidth + gridColumnSpacing))
     }
 }

--- a/Media MuncherTests/ConstantsTests.swift
+++ b/Media MuncherTests/ConstantsTests.swift
@@ -44,18 +44,18 @@ final class ConstantsTests: XCTestCase {
     func testGridColumnsCountCalculation() {
         // Test with various window widths
         let testCases: [(width: CGFloat, expectedColumns: Int)] = [
-            (150, 1),   // Very narrow window
+            (150, 0),   // Too narrow for a column
             (300, 2),   // Small window
             (600, 4),   // Medium window
-            (1200, 9),  // Large window
+            (1200, 8),  // Large window
             (1920, 14)  // Very wide window
         ]
         
         for testCase in testCases {
             let actualColumns = Constants.gridColumnsCount(for: testCase.width)
-            XCTAssertEqual(actualColumns, testCase.expectedColumns, 
+            XCTAssertEqual(actualColumns, testCase.expectedColumns,
                           "Width \(testCase.width) should produce \(testCase.expectedColumns) columns, got \(actualColumns)")
-            XCTAssertGreaterThanOrEqual(actualColumns, 1, "Should always have at least 1 column")
+            XCTAssertGreaterThanOrEqual(actualColumns, 0, "Columns count should never be negative")
         }
     }
     
@@ -65,7 +65,7 @@ final class ConstantsTests: XCTestCase {
         XCTAssertEqual(Constants.gridColumnsCount(for: -100), 0, "Negative width should produce 0 columns")
         
         // Test exact boundary case
-        let exactBoundary = Constants.gridPadding + Constants.gridColumnWidth + Constants.gridColumnSpacing
+        let exactBoundary = Constants.gridPadding * 2 + Constants.gridColumnWidth + Constants.gridColumnSpacing
         XCTAssertEqual(Constants.gridColumnsCount(for: exactBoundary), 1, "Exact boundary should produce 1 column")
     }
 }

--- a/PRD.md
+++ b/PRD.md
@@ -214,6 +214,12 @@ The specific file extensions for each category in **ST-5** are:
 - Enhanced date-based organization to work correctly for files without EXIF/metadata dates
 - Added comprehensive test coverage for modification date fallback behavior with filesystem interaction
 
+### 2025-08-05 – Grid Layout Calculation Fix
+- **UI fix**: Corrected grid column calculation to properly account for padding on both sides of the layout
+- Fixed formula from `width - gridPadding` to `max(0, width - gridPadding * 2)` for accurate column counts
+- Added defensive programming with `max(0, ...)` to prevent negative available width calculations
+- Updated all test cases with correct expected values and improved edge case handling
+
 ---
 **Legend**:  
 *Finished* – Implemented and shipped in `main`.  


### PR DESCRIPTION
## Summary
- compute grid column count using padding on both sides
- update tests for new column expectations

## Testing
- `swift test` *(fails: package 'package.swift' is using Swift tools version 3.1.0 which is no longer supported)*
- `xcodebuild -scheme "Media Muncher" -project "Media Muncher.xcodeproj" build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68918679aed483329d2a4510ff1dc99b